### PR TITLE
Added IOCTL functions to read values, I2CError, fixed bugs when calibrating 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# BME280 
+# BME280
 
-A Linux device driver for the Bosch BME280 temperature, pressure, humidity sensor using the I2C protocol, written in C. 
+A Linux device driver for the Bosch BME280 temperature, pressure, humidity sensor using the I2C protocol, written in C.
 
 <img src="https://user-images.githubusercontent.com/28817028/210186916-9eb196d5-eaf1-4856-9faa-2ae71ba2e0b0.png" width=50% height=50%>
 
@@ -24,14 +24,14 @@ i2cdetect -y 1
 The output of `i2cdetect` should be something like
 ```
      0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
-00:                         -- -- -- -- -- -- -- -- 
-10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
-20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
-30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
-40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
-50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
-60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
-70: -- -- -- -- -- -- 76 --                         
+00:                         -- -- -- -- -- -- -- --
+10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+70: -- -- -- -- -- -- 76 --
 ```
 Which indicates that the sensor is available at 0x76.
 
@@ -50,13 +50,13 @@ sudo insmod bme280.ko
 ```
 
 A device file should now be created in `/dev/bme280`. You can read continuous measurements
-as a stream by reading the device file: 
+as a stream by reading the device file:
 ```
 chmod 666 /dev/bme280 # enable read access
 cat < /dev/bme280
 ```
 
-To remove the driver, run 
+To remove the driver, run
 ```
 sudo rmmod bme280
 ```
@@ -78,7 +78,7 @@ To interpret this line:
 
 ## Running the example
 
-The userspace example is a simple Rust program that reads the driver file as a stream and parses it. The driver is expected to be initialized already, or else reading the driver file will not work. To start it, run 
+The userspace example is a simple Rust program that reads the driver file as a stream and parses it. The driver is expected to be initialized already, or else reading the driver file will not work. To start it, run
 ```
 cd user/ && cargo run
 ```
@@ -86,4 +86,20 @@ cd user/ && cargo run
 Here is a line of expected console output:
 ```
 Temperature: 29.23C Pressure: 97290.80Pa Humidity: 26.35%
+```
+
+## Running the IOCTL example
+
+The IOCTL example is a simple C program that reads the driver file and uses the ioctl interface to read the sensor data (temperature, humidity and pressure) separately instead of reading it in one line. Like in the Rust example, the driver is expected to be initialized already, or else reading the driver file will not work. To start it, run
+
+```
+cd ioctl_example/ && make
+./bme280
+```
+
+Here is a line of expected console output:
+```
+Temperature: 29.720000 C
+Humidity: 42.366211 %
+Pressure: 96080.445312 Pa
 ```

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -5,6 +5,9 @@ CSTD_FLAG := -std=gnu11
 all:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
 
+install:
+	make -C /lib/modules/$(shell uname -r)/build M="$(CURDIR)" modules_install
+
 clean:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
 

--- a/driver/bme280.c
+++ b/driver/bme280.c
@@ -380,7 +380,7 @@ static int init_driver(void)
   if (id != 0x60)
   {
     pr_err("bme280: id is not 0x60\n");
-    goto KernelError;
+    goto I2CError;
   }
 
   pr_info("id is 0x%x\n", id);
@@ -405,6 +405,10 @@ static int init_driver(void)
   pr_info("bme280: successfully init module\n");
 
   return ret;
+I2CError:
+  i2c_unregister_device(bme280_i2c_client);
+  i2c_del_driver(&bme280_i2c_driver);
+  cdev_del(&bme280_cdev);
 KernelError:
   device_destroy(dev_class, dev_num);
 DeviceError:

--- a/ioctl_example/Makefile
+++ b/ioctl_example/Makefile
@@ -1,0 +1,10 @@
+CC = gcc
+CFLAGS = -Wall -Wextra
+
+all: bme280
+
+bme280: user.c
+	$(CC) $(CFLAGS) -o bme280 user.c
+
+clean:
+	rm -f user

--- a/ioctl_example/user.c
+++ b/ioctl_example/user.c
@@ -1,0 +1,41 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+
+#define DEVICE_FILE_NAME "/dev/bme280"
+#define IOCTL_GET_TEMPERATURE _IOR('t', 1, long int)
+#define IOCTL_GET_HUMIDITY    _IOR('h', 2, long int)
+#define IOCTL_GET_PRESSURE    _IOR('p', 3, long int)
+
+int main() {
+    int fd;
+    long int value;
+
+    fd = open(DEVICE_FILE_NAME, 0);
+    if (fd < 0) {
+        perror("Failed to open the device");
+        return EXIT_FAILURE;
+    }
+
+    if (ioctl(fd, IOCTL_GET_TEMPERATURE, &value) < 0) {
+        perror("IOCTL_GET_TEMPERATURE failed");
+    } else {
+        printf("Temperature: %f C\n", value / 100.0);
+    }
+
+    if (ioctl(fd, IOCTL_GET_HUMIDITY, &value) < 0) {
+        perror("IOCTL_GET_HUMIDITY failed");
+    } else {
+        printf("Humidity: %f %%\n", value / 1024.0);
+    }
+
+    if (ioctl(fd, IOCTL_GET_PRESSURE, &value) < 0) {
+        perror("IOCTL_GET_PRESSURE failed");
+    } else {
+        printf("Pressure: %f Pa\n", value / 256.0);
+    }
+
+    close(fd);
+    return 0;
+}


### PR DESCRIPTION
- Added an IOCTL handler to read all the values separately.
- IOCTL C example, added it in README
- install command to install the module in Makefile
- Fixed retrieving the H1 digit, read the coresponding register instead of non existing index 24
- Reordered the calibration registers, like in other libraries for BME280, so that the humidity is calibrated in a right way
- Added a label I2CError to fall when the device id is not 0x60 (it won't load the driver if the sensor is not connected)